### PR TITLE
Updated to the current path structure

### DIFF
--- a/icpconfigApp/src/icpconfig.cpp
+++ b/icpconfigApp/src/icpconfig.cpp
@@ -464,41 +464,39 @@ static int loadIOCs(MAC_HANDLE *h, const std::string& config_name, const std::st
 	printf("icpconfigLoad: Loading IOC sim level \"%s\"\n", config_name.c_str());
 	pugi::xpath_query ioc_query("/iocs/ioc[@name=$iocname]", &vars);
 	pugi::xpath_node_set ioc_node = ioc_query.evaluate_node_set(doc);
-    std::string sim_level;
-    bool disable = false;
     if (ioc_node.size() > 0)
     {
-	    sim_level = ioc_node[0].node().attribute("simlevel").value();
-        disable = ioc_node[0].node().attribute("disable").as_bool();
-    }
-    if (sim_level == "none")
-    {
-        setValue(h, "DEVSIM", "0", config_name.c_str());
-        setValue(h, "RECSIM", "0", config_name.c_str());
-    }
-    else if (sim_level == "recsim")
-    {
-        setValue(h, "DEVSIM", "0", config_name.c_str());
-        setValue(h, "RECSIM", "1", config_name.c_str());
-    }
-    else if (sim_level == "devsim")
-    {
-        setValue(h, "DEVSIM", "1", config_name.c_str());
-        setValue(h, "RECSIM", "0", config_name.c_str());
-    }
-    else
-    {
-		errlogPrintf("icpconfigLoad: unknown or unspecified sim level \"%s\" - assuming not simulating\n", sim_level.c_str());
-        setValue(h, "DEVSIM", "0", config_name.c_str());
-        setValue(h, "RECSIM", "0", config_name.c_str());
-    }    
-    if (disable)
-    {
-        setValue(h, "DISABLE", "1", config_name.c_str());
-    }
-    else
-    {
-        setValue(h, "DISABLE", "0", config_name.c_str());
+	    std::string sim_level = ioc_node[0].node().attribute("simlevel").value();
+        bool disable = ioc_node[0].node().attribute("disable").as_bool();
+        if (sim_level == "none")
+        {
+            setValue(h, "DEVSIM", "0", config_name.c_str());
+            setValue(h, "RECSIM", "0", config_name.c_str());
+        }
+        else if (sim_level == "recsim")
+        {
+            setValue(h, "DEVSIM", "0", config_name.c_str());
+            setValue(h, "RECSIM", "1", config_name.c_str());
+        }
+        else if (sim_level == "devsim")
+        {
+            setValue(h, "DEVSIM", "1", config_name.c_str());
+            setValue(h, "RECSIM", "0", config_name.c_str());
+        }
+        else
+        {
+		    errlogPrintf("icpconfigLoad: unknown sim level \"%s\" - assuming not simulating\n", sim_level.c_str());
+            setValue(h, "DEVSIM", "0", config_name.c_str());
+            setValue(h, "RECSIM", "0", config_name.c_str());
+        }    
+        if (disable)
+        {
+            setValue(h, "DISABLE", "1", config_name.c_str());
+        }
+        else
+        {
+            setValue(h, "DISABLE", "0", config_name.c_str());
+		}
     }
 	// ioc macros
 	printf("icpconfigLoad: Loading IOC macros for \"%s\"\n", config_name.c_str());

--- a/icpconfigApp/src/icpconfig.cpp
+++ b/icpconfigApp/src/icpconfig.cpp
@@ -376,7 +376,7 @@ static int icpconfigLoadMain(const std::string& config_name, const std::string& 
 	else
 	{
 	    printf("icpconfigLoad: last configuration was \"%s\"\n", configName.c_str());
-	    loadConfig(h, configName, config_root, ioc_name, ioc_group, false, false, verbose);
+	    loadConfig(h, configName, config_root + "/configurations/", ioc_name, ioc_group, false, false, verbose);
 	}
 // old style files
     loadMacroFile(h, config_root + "/globals.txt", configName, config_root, ioc_name, ioc_group, false, false, verbose);


### PR DESCRIPTION
My slightly hacked testing sees this pull in a macro from a config (that has been set via a GUI), it probably needs checking by the expert.

To test:
Have something which has a readable macro when running, check that a macro set via the gui (so stored in the iocs.xml for the configuration) is used in that position.
