### PR TITLE
Add new icpEnvExpand tool

### DIFF
--- a/icpconfigApp/src/Makefile
+++ b/icpconfigApp/src/Makefile
@@ -21,10 +21,15 @@ icpconfig_SRCS += icpconfig.cpp
 icpconfig_LIBS += utilities pugixml
 icpconfig_LIBS += $(EPICS_BASE_IOC_LIBS)
 
-PROD_IOC += icpconfigCheck
+PROD_IOC += icpconfigCheck icpconfigEnvExpand
+
 icpconfigCheck_SRCS += icpconfigCheck.cpp
 icpconfigCheck_LIBS += icpconfig utilities pugixml pcre
 icpconfigCheck_LIBS += $(EPICS_BASE_IOC_LIBS)
+
+icpconfigEnvExpand_SRCS += icpconfigEnvExpand.cpp
+icpconfigEnvExpand_LIBS += icpconfig utilities pugixml pcre
+icpconfigEnvExpand_LIBS += $(EPICS_BASE_IOC_LIBS)
 
 #===========================
 

--- a/icpconfigApp/src/icpconfig.h
+++ b/icpconfigApp/src/icpconfig.h
@@ -3,5 +3,6 @@
 
 enum icpOptions { VerboseOutput = 0x1 };
 epicsShareExtern int icpconfigCheck(const std::string& configName, const std::string& ioc_name, const std::string& ioc_group, const std::string& configHost, const std::string& configBase, int options);
+epicsShareExtern int icpconfigEnvExpand(const std::string& inFileName, const std::string& outFileName, const std::string& configName);
 
 #endif /* ICPCONFIG_H */

--- a/icpconfigApp/src/icpconfigEnvExpand.cpp
+++ b/icpconfigApp/src/icpconfigEnvExpand.cpp
@@ -1,0 +1,73 @@
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <errno.h>
+#include <math.h>
+#include <exception>
+#include <algorithm>
+#include <stdexcept>
+#include <iostream>
+#include <map>
+#include <list>
+#include <string>
+#include <time.h>
+#include <sstream>
+#include <fstream>
+
+#include "epicsStdlib.h"
+#include "epicsString.h"
+#include "dbDefs.h"
+#include "epicsMutex.h"
+#include "dbBase.h"
+#include "dbStaticLib.h"
+#include "dbFldTypes.h"
+#include "dbCommon.h"
+#include "dbAccessDefs.h"
+#include <epicsTypes.h>
+#include <epicsTime.h>
+#include <epicsThread.h>
+#include <epicsString.h>
+#include <epicsTimer.h>
+#include <epicsMutex.h>
+#include <iocsh.h>
+#include <initHooks.h>
+#include "envDefs.h"
+#include "macLib.h"
+#include "errlog.h"
+#include "dbAccess.h"
+#include "dbTest.h"
+#include "dbStaticLib.h"
+#include "errlog.h"
+
+#ifdef _WIN32
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
+
+#include "pugixml.hpp"
+
+#include "utilities.h"
+
+#include "icpconfig.h"
+
+#include <epicsExport.h>
+
+int main(int argc, char* argv[])
+{
+    std::string inFileName, outFileName, configName;
+	if (argc > 1)
+	{
+	    inFileName = argv[1];
+	}
+	if (argc > 2)
+	{
+	    outFileName = argv[2];
+	}
+	if (argc > 3)
+	{
+	    configName = argv[3];
+	}
+    icpconfigEnvExpand(inFileName, outFileName, configName);
+    return 0;
+}


### PR DESCRIPTION
This allow you to process a file in much the same way as
EPICS MSI but it will use the macros defined in the current
configuration and globals.txt

```
icpconfigEnvExpand  in_file.txt out_file.txt
```

Will replace $() instances in in_file with macros from the
current configuration

See ISISComputingGroup/IBEX#1316
