### PR TITLE
Add icpconfigGetMacros

### DIFF
--- a/icpconfigApp/src/Makefile
+++ b/icpconfigApp/src/Makefile
@@ -21,7 +21,7 @@ icpconfig_SRCS += icpconfig.cpp
 icpconfig_LIBS += utilities pugixml
 icpconfig_LIBS += $(EPICS_BASE_IOC_LIBS)
 
-PROD_IOC += icpconfigCheck icpconfigEnvExpand
+PROD_IOC += icpconfigCheck icpconfigEnvExpand icpconfigGetMacros
 
 icpconfigCheck_SRCS += icpconfigCheck.cpp
 icpconfigCheck_LIBS += icpconfig utilities pugixml pcre
@@ -30,6 +30,10 @@ icpconfigCheck_LIBS += $(EPICS_BASE_IOC_LIBS)
 icpconfigEnvExpand_SRCS += icpconfigEnvExpand.cpp
 icpconfigEnvExpand_LIBS += icpconfig utilities pugixml pcre
 icpconfigEnvExpand_LIBS += $(EPICS_BASE_IOC_LIBS)
+
+icpconfigGetMacros_SRCS += icpconfigGetMacros.cpp
+icpconfigGetMacros_LIBS += icpconfig utilities pugixml pcre
+icpconfigGetMacros_LIBS += $(EPICS_BASE_IOC_LIBS)
 
 #===========================
 

--- a/icpconfigApp/src/icpconfig.cpp
+++ b/icpconfigApp/src/icpconfig.cpp
@@ -520,13 +520,12 @@ epicsShareExtern std::string icpconfigGetMacros(const std::string& iocName, cons
 	if (h != NULL)
 	{
 		macDeleteHandle(h);
-        std::list<std::string> names_and_values;
+        std::map<std::string, std::string> names_and_values;
         for(std::map<std::string,MacroItem>::const_iterator it = macro_map.begin(); it != macro_map.end(); ++it)
         {
-            names_and_values.push_back(it->first);
-            names_and_values.push_back(it->second.value);
+            names_and_values[it->first] = it->second.value;
         }
-        return json_list_to_array(names_and_values);
+        return json_map_to_node(names_and_values);
 	}
 	else
 	{

--- a/icpconfigApp/src/icpconfig.cpp
+++ b/icpconfigApp/src/icpconfig.cpp
@@ -501,6 +501,28 @@ epicsShareExtern int icpconfigEnvExpand(const std::string& inFileName, const std
 	}
 }
 
+epicsShareExtern std::string icpconfigGetMacros(const std::string& configName, const std::string& ioc_name, const std::string& configHost)
+{
+    icpOptions options = VerboseOutput;
+	MAC_HANDLE* h = icpconfigLoadMain(configName, ioc_name, "", options, configHost, "");
+	if (h != NULL)
+	{
+		macDeleteHandle(h);
+        std::list<std::string> names_and_values;
+        for(std::map<std::string,MacroItem>::const_iterator it = macro_map.begin(); it != macro_map.end(); ++it)
+        {
+            names_and_values.push_back(it->first);
+            names_and_values.push_back(it->second.value);
+        }
+        return json_list_to_array(names_and_values);
+	}
+	else
+	{
+		return "";
+	}
+}
+
+
 static int loadIOCs(MAC_HANDLE *h, const std::string& config_name, const std::string& config_root, const std::string& ioc_name, const std::string& ioc_group, bool warn_if_not_found, bool filter, bool verbose)
 {
 	pugi::xml_document doc;

--- a/icpconfigApp/src/icpconfig.cpp
+++ b/icpconfigApp/src/icpconfig.cpp
@@ -511,7 +511,7 @@ epicsShareExtern int icpconfigEnvExpand(const std::string& inFileName, const std
 	}
 }
 
-epicsShareExtern std::string icpconfigGetMacros(const std::string& configName, const std::string& ioc_name, const std::string& configHost)
+epicsShareExtern std::string icpconfigGetMacros(const std::string& ioc_name, const std::string& configName, const std::string& configHost)
 {
     icpOptions options = QuietOutput;
 	MAC_HANDLE* h = icpconfigLoadMain(configName, ioc_name, "", options, configHost, "");

--- a/icpconfigApp/src/icpconfig.cpp
+++ b/icpconfigApp/src/icpconfig.cpp
@@ -511,10 +511,12 @@ epicsShareExtern int icpconfigEnvExpand(const std::string& inFileName, const std
 	}
 }
 
-epicsShareExtern std::string icpconfigGetMacros(const std::string& ioc_name, const std::string& configName, const std::string& configHost)
+epicsShareExtern std::string icpconfigGetMacros(const std::string& iocName, const std::string& configName, const std::string& configHost)
 {
     icpOptions options = QuietOutput;
-	MAC_HANDLE* h = icpconfigLoadMain(configName, ioc_name, "", options, configHost, "");
+	std::string ioc_name = setIOCName(iocName.c_str());
+	std::string ioc_group = getIOCGroup();
+	MAC_HANDLE* h = icpconfigLoadMain(configName, ioc_name, ioc_group, options, configHost, "");
 	if (h != NULL)
 	{
 		macDeleteHandle(h);

--- a/icpconfigApp/src/icpconfig.h
+++ b/icpconfigApp/src/icpconfig.h
@@ -4,6 +4,6 @@
 enum icpOptions { VerboseOutput = 0x1, QuietOutput=0x2 };
 epicsShareExtern int icpconfigCheck(const std::string& configName, const std::string& ioc_name, const std::string& ioc_group, const std::string& configHost, const std::string& configBase, int options);
 epicsShareExtern int icpconfigEnvExpand(const std::string& inFileName, const std::string& outFileName, const std::string& configName);
-epicsShareExtern std::string icpconfigGetMacros(const std::string& ioc_name, const std::string& configName, const std::string& configHost);
+epicsShareExtern std::string icpconfigGetMacros(const std::string& iocName, const std::string& configName, const std::string& configHost);
 
 #endif /* ICPCONFIG_H */

--- a/icpconfigApp/src/icpconfig.h
+++ b/icpconfigApp/src/icpconfig.h
@@ -1,7 +1,7 @@
 #ifndef ICPCONFIG_H
 #define ICPCONFIG_H
 
-enum icpOptions { VerboseOutput = 0x1 };
+enum icpOptions { VerboseOutput = 0x1, QuietOutput=0x2 };
 epicsShareExtern int icpconfigCheck(const std::string& configName, const std::string& ioc_name, const std::string& ioc_group, const std::string& configHost, const std::string& configBase, int options);
 epicsShareExtern int icpconfigEnvExpand(const std::string& inFileName, const std::string& outFileName, const std::string& configName);
 epicsShareExtern std::string icpconfigGetMacros(const std::string& configName, const std::string& ioc_name, const std::string& configHost);

--- a/icpconfigApp/src/icpconfig.h
+++ b/icpconfigApp/src/icpconfig.h
@@ -4,5 +4,6 @@
 enum icpOptions { VerboseOutput = 0x1 };
 epicsShareExtern int icpconfigCheck(const std::string& configName, const std::string& ioc_name, const std::string& ioc_group, const std::string& configHost, const std::string& configBase, int options);
 epicsShareExtern int icpconfigEnvExpand(const std::string& inFileName, const std::string& outFileName, const std::string& configName);
+epicsShareExtern std::string icpconfigGetMacros(const std::string& configName, const std::string& ioc_name, const std::string& configHost);
 
 #endif /* ICPCONFIG_H */

--- a/icpconfigApp/src/icpconfig.h
+++ b/icpconfigApp/src/icpconfig.h
@@ -4,6 +4,6 @@
 enum icpOptions { VerboseOutput = 0x1, QuietOutput=0x2 };
 epicsShareExtern int icpconfigCheck(const std::string& configName, const std::string& ioc_name, const std::string& ioc_group, const std::string& configHost, const std::string& configBase, int options);
 epicsShareExtern int icpconfigEnvExpand(const std::string& inFileName, const std::string& outFileName, const std::string& configName);
-epicsShareExtern std::string icpconfigGetMacros(const std::string& configName, const std::string& ioc_name, const std::string& configHost);
+epicsShareExtern std::string icpconfigGetMacros(const std::string& ioc_name, const std::string& configName, const std::string& configHost);
 
 #endif /* ICPCONFIG_H */

--- a/icpconfigApp/src/icpconfigGetMacros.cpp
+++ b/icpconfigApp/src/icpconfigGetMacros.cpp
@@ -68,6 +68,6 @@ int main(int argc, char* argv[])
 	{
 	    configHost = argv[3];
 	}
-    icpconfigGetMacros(configName, ioc_name, configHost);
+    std::cout << icpconfigGetMacros(configName, ioc_name, configHost) << std::endl;
     return 0;
 }

--- a/icpconfigApp/src/icpconfigGetMacros.cpp
+++ b/icpconfigApp/src/icpconfigGetMacros.cpp
@@ -1,0 +1,73 @@
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <errno.h>
+#include <math.h>
+#include <exception>
+#include <algorithm>
+#include <stdexcept>
+#include <iostream>
+#include <map>
+#include <list>
+#include <string>
+#include <time.h>
+#include <sstream>
+#include <fstream>
+
+#include "epicsStdlib.h"
+#include "epicsString.h"
+#include "dbDefs.h"
+#include "epicsMutex.h"
+#include "dbBase.h"
+#include "dbStaticLib.h"
+#include "dbFldTypes.h"
+#include "dbCommon.h"
+#include "dbAccessDefs.h"
+#include <epicsTypes.h>
+#include <epicsTime.h>
+#include <epicsThread.h>
+#include <epicsString.h>
+#include <epicsTimer.h>
+#include <epicsMutex.h>
+#include <iocsh.h>
+#include <initHooks.h>
+#include "envDefs.h"
+#include "macLib.h"
+#include "errlog.h"
+#include "dbAccess.h"
+#include "dbTest.h"
+#include "dbStaticLib.h"
+#include "errlog.h"
+
+#ifdef _WIN32
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
+
+#include "pugixml.hpp"
+
+#include "utilities.h"
+
+#include "icpconfig.h"
+
+#include <epicsExport.h>
+
+int main(int argc, char* argv[])
+{
+   std::string configName, ioc_name, configHost;
+	if (argc > 1)
+	{
+	    configName = argv[1];
+	}
+	if (argc > 2)
+	{
+	    ioc_name = argv[2];
+	}
+	if (argc > 3)
+	{
+	    configHost = argv[3];
+	}
+    icpconfigGetMacros(configName, ioc_name, configHost);
+    return 0;
+}

--- a/icpconfigApp/src/icpconfigGetMacros.cpp
+++ b/icpconfigApp/src/icpconfigGetMacros.cpp
@@ -55,19 +55,19 @@
 
 int main(int argc, char* argv[])
 {
-   std::string configName, ioc_name, configHost;
+    std::string iocName, configName, configHost;
 	if (argc > 1)
 	{
-	    configName = argv[1];
+	    iocName = argv[1];
 	}
 	if (argc > 2)
 	{
-	    ioc_name = argv[2];
+	    configName = argv[2];
 	}
 	if (argc > 3)
 	{
 	    configHost = argv[3];
 	}
-    std::cout << icpconfigGetMacros(configName, ioc_name, configHost) << std::endl;
+    std::cout << icpconfigGetMacros(iocName, configName, configHost) << std::endl;
     return 0;
 }

--- a/test_getmacros.bat
+++ b/test_getmacros.bat
@@ -3,6 +3,7 @@ REM as we setlocal, MACROS will not be defined after we exit bat script
 setlocal
 REM give IOC name as first argument to get better filtered output
 set "GETMACROS=%~dp0bin\%EPICS_HOST_ARCH%\icpconfigGetMacros.exe"
-rem for /f "usebackq tokens^=*^ delims^=^ eol^=" %%a in ( `%GETMACROS%` ) do ( set "MACROS=%%a" )
-for /f "usebackq tokens=* delims=" %%a in ( `%GETMACROS%` ) do ( set "MACROS=%%a" )
+set "IOCNAME=myioc"
+REM need this funny syntax to be able to set eol correctly - see google
+for /f usebackq^ tokens^=*^ delims^=^ eol^= %%a in ( `%GETMACROS%` ) do ( set "MACROS=%%a" )
 echo Macro JSON is %MACROS%

--- a/test_getmacros.bat
+++ b/test_getmacros.bat
@@ -3,7 +3,7 @@ REM as we setlocal, MACROS will not be defined after we exit bat script
 setlocal
 REM give IOC name as first argument to get better filtered output
 set "GETMACROS=%~dp0bin\%EPICS_HOST_ARCH%\icpconfigGetMacros.exe"
-set "IOCNAME=myioc"
+set "MYIOCNAME=%1"
 REM need this funny syntax to be able to set eol correctly - see google
-for /f usebackq^ tokens^=*^ delims^=^ eol^= %%a in ( `%GETMACROS%` ) do ( set "MACROS=%%a" )
+for /f usebackq^ tokens^=*^ delims^=^ eol^= %%a in ( `%GETMACROS% %MYIOCNAME%` ) do ( set "MACROS=%%a" )
 echo Macro JSON is %MACROS%

--- a/test_getmacros.bat
+++ b/test_getmacros.bat
@@ -1,0 +1,8 @@
+@echo off
+REM as we setlocal, MACROS will not be defined after we exit bat script
+setlocal
+REM give IOC name as first argument to get better filtered output
+set "GETMACROS=%~dp0bin\%EPICS_HOST_ARCH%\icpconfigGetMacros.exe"
+rem for /f "usebackq tokens^=*^ delims^=^ eol^=" %%a in ( `%GETMACROS%` ) do ( set "MACROS=%%a" )
+for /f "usebackq tokens=* delims=" %%a in ( `%GETMACROS%` ) do ( set "MACROS=%%a" )
+echo Macro JSON is %MACROS%


### PR DESCRIPTION
Add new icpconfigGetMacros command - this can be run from the command line and prints a JSON format list to standard output of the macros defined. You should pass the IOC name as the first argument to get better output.

See  test_getmacros.bat  for how to capture output in a bat and set an environment variable for later use by another program

See ISISComputingGroup/IBEX#5452 and ISISComputingGroup/IBEX#5198 