### PR TITLE
Ticket5633

### DIFF
--- a/icpconfigApp/src/icpconfig.cpp
+++ b/icpconfigApp/src/icpconfig.cpp
@@ -338,17 +338,21 @@ static void icpconfigReport()
 
 // If running IOC tests, load in IOC test macros 
 static void loadTestMacros(MAC_HANDLE *h, const std::string& config_name, const std::string& config_root, const std::string& ioc_name, const std::string& ioc_group, bool verbose){
-	const char *testdevsim, *testrecsim;
+	std::string testdevsim, testrecsim, var_dir;
 	bool testdevsim_is_empty, testrecsim_is_empty;
 
 	testdevsim = macEnvExpand("$(TESTDEVSIM=)");
 	testrecsim = macEnvExpand("$(TESTRECSIM=)");
 
-	testdevsim_is_empty = nullOrZeroLength(testdevsim);
-	testrecsim_is_empty = nullOrZeroLength(testrecsim);
+	var_dir = macEnvExpand("$(ICPVARDIR)");
 
-	if (!testdevsim_is_empty || !testrecsim_is_empty) {
-		loadMacroFile(h, "C:/Instrument/var/tmp/test_macros.txt", config_name, config_root, ioc_name, ioc_group, false, false, verbose);
+	testdevsim_is_empty = testdevsim.size() == 0;
+	testrecsim_is_empty = testrecsim.size() == 0;
+
+	if ((!testdevsim_is_empty || !testrecsim_is_empty) && (var_dir.size() == 0)) {
+		errlogPrintf("icpconfigLoad: failed (ICPVARDIR environment variable not set - cannot load test macros)\n");
+	} else if ((!testdevsim_is_empty || !testrecsim_is_empty)) {
+		loadMacroFile(h, var_dir + "/tmp/test_macros.txt", config_name, config_root, ioc_name, ioc_group, false, false, verbose);
 		simulate = true;
 		setValue(h, "SIMULATE", "1", "{simulation mode for tests}");
 	}

--- a/icpconfigApp/src/icpconfig.cpp
+++ b/icpconfigApp/src/icpconfig.cpp
@@ -417,6 +417,26 @@ static MAC_HANDLE* icpconfigLoadMain(const std::string& config_name, const std::
 	loadMacroFile(h, config_root + "/" + ioc_group + ".txt", configName, config_root, ioc_name, ioc_group, false, false, verbose);
 	loadMacroFile(h, config_root + "/" + ioc_name + ".txt", configName, config_root, ioc_name, ioc_group, false, false, verbose);
 
+	const char *test_devsim, *test_recsim;
+ 
+	test_devsim = macEnvExpand("$(TESTDEVSIM=)");
+	test_recsim = macEnvExpand("$(TESTRECSIM=)");
+	
+	if (!nullOrZeroLength(test_devsim))  {
+		loadMacroFile(h, "C:/Instrument/var/tmp/test_macros.txt", configName, config_root, ioc_name, ioc_group, false, false, verbose);
+		simulate = true;
+		devsim = true;
+		setValue(h, "SIMULATE", "1", "{simulation mode for tests}");
+		setValue(h, "DEVSIM", "1", "{simulation mode for tests}");
+	} else if (!nullOrZeroLength(test_recsim)) {
+		loadMacroFile(h, "C:/Instrument/var/tmp/test_macros.txt", configName, config_root, ioc_name, ioc_group, false, false, verbose);
+		simulate = true;
+		recsim = true;
+		setValue(h, "SIMULATE", "1", "{simulation mode for tests}");
+		setValue(h, "RECSIM", "1", "{simulation mode for tests}");
+	}
+	
+
     if ( (devsim || recsim) && !simulate )
     {
         setValue(h, "SIMULATE", "1", "{icpconfig final adjustment}");


### PR DESCRIPTION
Description of work:
Looks for an old-style macro file (like globals.txt) when TESTDEVSIM or TESTRECSIM environment variables are set

To test:
1. Make sure tests still run in devsim and recsim correctly
1. Make sure IOCs load up in devsim/recsim/normally when not running through the ioc tests

Ticket:
https://github.com/ISISComputingGroup/IBEX/issues/5336