### PR TITLE
Ticket8445 make config xml single source of truth

### DIFF
--- a/icpconfigApp/src/icpconfig.cpp
+++ b/icpconfigApp/src/icpconfig.cpp
@@ -565,6 +565,32 @@ epicsShareExtern void icpconfigGetMacros(const std::string& iocName, const std::
     }
 }
 
+static int loadDefaultMacros(MAC_HANDLE *h, const std::string& config_name){
+	pugi::xml_document confXMLDoc;
+	std::string confXML = std::string(macEnvExpand("$(TOP)")) +"/iocBoot/" + std::string(macEnvExpand("$(IOC)")) +"/config.xml";
+	pugi::xml_parse_result result = confXMLDoc.load_file(confXML.c_str());
+	if (!result)
+	{
+	    std::cerr << "icpconfigLoad: Error in \"" << confXML << "\" " << result.description() << " at offset " << result.offset << std::endl;
+		return -1;
+	}
+	pugi::xpath_node_set default_macros = confXMLDoc.select_nodes("/ioc_config/config_part/macros/macro");
+	default_macros.sort(); // forward document order
+	if (!quiet)
+    {
+	    printf("icpconfigLoad: Checking %d macro(s) for default values in %s\n", (int)default_macros.size(), confXML.c_str());
+    }
+	for (pugi::xpath_node_set::const_iterator it = default_macros.begin(); it != default_macros.end(); ++it)
+	{
+		if (it->node().attribute("hasDefault").as_bool()) {
+			std::string name = it->node().attribute("name").value();
+			std::string value = it->node().attribute("defaultValue").value();
+        	setValue(h, name.c_str(), value.c_str(), config_name.c_str());
+		}
+	}
+	return 0;
+}
+
 static int loadIOCs(MAC_HANDLE *h, const std::string& config_name, const std::string& config_root, const std::string& ioc_name, const std::string& ioc_group, bool warn_if_not_found, bool filter, bool verbose)
 {
 	pugi::xml_document doc;
@@ -582,29 +608,10 @@ static int loadIOCs(MAC_HANDLE *h, const std::string& config_name, const std::st
 	vars.set("iocname",ioc_name.c_str());
 	vars.set("iocgroup",ioc_group.c_str());
 	// default macros
-
-    pugi::xml_document confXMLDoc;
-	std::string confXML = std::string(macEnvExpand("$(TOP)")) +"/iocBoot/" + std::string(macEnvExpand("$(IOC)")) +"/config.xml";
-	result = confXMLDoc.load_file(confXML.c_str());
-	if (!result)
-	{
-	    std::cerr << "icpconfigLoad: Error in \"" << confXML << "\" " << result.description() << " at offset " << result.offset << std::endl;
+	if (loadDefaultMacros(h, config_name)) {
 		return -1;
 	}
-	pugi::xpath_node_set default_macros = confXMLDoc.select_nodes("/ioc_config/config_part/macros/macro");
-	default_macros.sort(); // forward document order
-	if (!quiet)
-    {
-	    printf("icpconfigLoad: checking %d macro(s) for default values in %s\n", (int)default_macros.size(), confXML.c_str());
-    }
-	for (pugi::xpath_node_set::const_iterator it = default_macros.begin(); it != default_macros.end(); ++it)
-	{
-		if (it->node().attribute("hasDefault").as_bool()) {
-			std::string name = it->node().attribute("name").value();
-			std::string value = it->node().attribute("defaultValue").value();
-        	setValue(h, name.c_str(), value.c_str(), config_name.c_str());
-		}
-	}
+    
     // ioc sim level
     if (!quiet)
     {

--- a/icpconfigApp/src/icpconfig.cpp
+++ b/icpconfigApp/src/icpconfig.cpp
@@ -575,23 +575,35 @@ static int loadIOCs(MAC_HANDLE *h, const std::string& config_name, const std::st
 	    std::cerr << "icpconfigLoad: Error in \"" << xfile << "\" " << result.description() << " at offset " << result.offset << std::endl;
 		return -1;
 	}
+	
 	pugi::xpath_variable_set vars;
 	vars.add("iocname", pugi::xpath_type_string);
 	vars.add("iocgroup", pugi::xpath_type_string);
 	vars.set("iocname",ioc_name.c_str());
 	vars.set("iocgroup",ioc_group.c_str());
 	// default macros
-    if (!quiet)
-    {
-	    printf("icpconfigLoad: Loading default macros for \"%s\"\n", config_name.c_str());
-    }
-	pugi::xpath_node_set default_macros = doc.select_nodes("/iocs/defaults/macros/macro");
+
+    pugi::xml_document confXMLDoc;
+	std::string confXML = std::string(macEnvExpand("$(TOP)")) +"/iocBoot/" + std::string(macEnvExpand("$(IOC)")) +"/config.xml";
+	result = confXMLDoc.load_file(confXML.c_str());
+	if (!result)
+	{
+	    std::cerr << "icpconfigLoad: Error in \"" << confXML << "\" " << result.description() << " at offset " << result.offset << std::endl;
+		return -1;
+	}
+	pugi::xpath_node_set default_macros = confXMLDoc.select_nodes("/ioc_config/config_part/macros/macro");
 	default_macros.sort(); // forward document order
+	if (!quiet)
+    {
+	    printf("icpconfigLoad: checking %d macro(s) for default values in %s\n", (int)default_macros.size(), confXML.c_str());
+    }
 	for (pugi::xpath_node_set::const_iterator it = default_macros.begin(); it != default_macros.end(); ++it)
 	{
-		std::string name = it->node().attribute("name").value();
-		std::string value = it->node().attribute("value").value();
-        setValue(h, name.c_str(), value.c_str(), config_name.c_str());
+		if (it->node().attribute("hasDefault").as_bool()) {
+			std::string name = it->node().attribute("name").value();
+			std::string value = it->node().attribute("defaultValue").value();
+        	setValue(h, name.c_str(), value.c_str(), config_name.c_str());
+		}
 	}
     // ioc sim level
     if (!quiet)
@@ -645,7 +657,14 @@ static int loadIOCs(MAC_HANDLE *h, const std::string& config_name, const std::st
 	{
 		std::string name = it->node().attribute("name").value();
 		std::string value = it->node().attribute("value").value();
-        setValue(h, name.c_str(), value.c_str(), config_name.c_str());
+		MacroItem& item = macro_map[name];
+		if (item.defined) {
+			if(value!=""){
+				setValue(h, name.c_str(), value.c_str(), config_name.c_str());
+			}
+		}else{
+        	setValue(h, name.c_str(), value.c_str(), config_name.c_str());
+		}
 	}
 	// ioc pvs
     if (!quiet)

--- a/icpconfigApp/src/icpconfig.cpp
+++ b/icpconfigApp/src/icpconfig.cpp
@@ -665,7 +665,6 @@ static int loadIOCs(MAC_HANDLE *h, const std::string& config_name, const std::st
 	{
 		std::string name = it->node().attribute("name").value();
 		std::string value = it->node().attribute("value").value();
-		MacroItem& item = macro_map[name];
 		setValue(h, name.c_str(), value.c_str(), config_name.c_str());
 	}
 	// ioc pvs

--- a/icpconfigApp/src/icpconfig.cpp
+++ b/icpconfigApp/src/icpconfig.cpp
@@ -567,7 +567,8 @@ epicsShareExtern void icpconfigGetMacros(const std::string& iocName, const std::
 
 static int loadDefaultMacros(MAC_HANDLE *h, const std::string& config_name){
 	pugi::xml_document confXMLDoc;
-	std::string confXML = std::string(macEnvExpand("$(TOP)")) +"/iocBoot/" + std::string(macEnvExpand("$(IOC)")) +"/config.xml";
+	std::string configXMLDir = std::string(macEnvExpand("$(IOC)")) +"/config.xml";
+	std::string confXML = std::string(macEnvExpand("$(TOP)")) +"/iocBoot/" + configXMLDir;
 	pugi::xml_parse_result result = confXMLDoc.load_file(confXML.c_str());
 	if (!result)
 	{
@@ -585,7 +586,7 @@ static int loadDefaultMacros(MAC_HANDLE *h, const std::string& config_name){
 		if (it->node().attribute("hasDefault").as_bool()) {
 			std::string name = it->node().attribute("name").value();
 			std::string value = it->node().attribute("defaultValue").value();
-        	setValue(h, name.c_str(), value.c_str(), config_name.c_str());
+        	setValue(h, name.c_str(), value.c_str(), configXMLDir.c_str());
 		}
 	}
 	return 0;

--- a/icpconfigApp/src/icpconfig.cpp
+++ b/icpconfigApp/src/icpconfig.cpp
@@ -666,13 +666,7 @@ static int loadIOCs(MAC_HANDLE *h, const std::string& config_name, const std::st
 		std::string name = it->node().attribute("name").value();
 		std::string value = it->node().attribute("value").value();
 		MacroItem& item = macro_map[name];
-		if (item.defined) {
-			if(value!=""){
-				setValue(h, name.c_str(), value.c_str(), config_name.c_str());
-			}
-		}else{
-        	setValue(h, name.c_str(), value.c_str(), config_name.c_str());
-		}
+		setValue(h, name.c_str(), value.c_str(), config_name.c_str());
 	}
 	// ioc pvs
     if (!quiet)

--- a/icpconfigApp/src/icpconfig.cpp
+++ b/icpconfigApp/src/icpconfig.cpp
@@ -108,6 +108,7 @@ struct PVSetItem
 };
 
 static std::map<std::string,PVSetItem> pvset_map;
+static bool defaultsSet = false;
 
 struct MacroItem
 {
@@ -589,6 +590,7 @@ static int loadDefaultMacros(MAC_HANDLE *h, const std::string& config_name){
         	setValue(h, name.c_str(), value.c_str(), configXMLDir.c_str());
 		}
 	}
+	defaultsSet = true;
 	return 0;
 }
 
@@ -608,9 +610,11 @@ static int loadIOCs(MAC_HANDLE *h, const std::string& config_name, const std::st
 	vars.add("iocgroup", pugi::xpath_type_string);
 	vars.set("iocname",ioc_name.c_str());
 	vars.set("iocgroup",ioc_group.c_str());
-	// default macros
-	if (loadDefaultMacros(h, config_name)) {
-		return -1;
+	// default macros but only if they aren't already loaded, this prevents overwrites
+	if(!defaultsSet){
+		if (loadDefaultMacros(h, config_name)) {
+			return -1;
+		}
 	}
     
     // ioc sim level


### PR DESCRIPTION
https://github.com/ISISComputingGroup/IBEX/issues/8445

replace reading defaults from `iocs.xml` which isn't used, with loading defaults from `config.xml`