### PR TITLE
Fix crash when ioc macro does not exist

### DIFF
--- a/icpconfigApp/src/icpconfig.cpp
+++ b/icpconfigApp/src/icpconfig.cpp
@@ -568,6 +568,10 @@ epicsShareExtern void icpconfigGetMacros(const std::string& iocName, const std::
 
 static int loadDefaultMacros(MAC_HANDLE *h, const std::string& config_name){
 	pugi::xml_document confXMLDoc;
+	if (macEnvExpand("$(IOC)") == NULL){
+		printf("icpconfigLoad: No $(IOC) macro, skipping load defaults\n");
+		return 0;
+	}
 	std::string configXMLDir = std::string(macEnvExpand("$(IOC)")) +"/config.xml";
 	std::string confXML = std::string(macEnvExpand("$(TOP)")) +"/iocBoot/" + configXMLDir;
 	pugi::xml_parse_result result = confXMLDoc.load_file(confXML.c_str());


### PR DESCRIPTION
Fix failing tests due to non iocs.